### PR TITLE
ci: single shared preview worker with branch banner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,6 +68,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-opennext-
 
+      - name: Set preview environment variables
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "NEXT_PUBLIC_PREVIEW=true" >> "$GITHUB_ENV"
+          echo "NEXT_PUBLIC_BRANCH_NAME=${{ github.head_ref }}" >> "$GITHUB_ENV"
+
       - name: Build with OpenNext
         run: npx opennextjs-cloudflare build
 
@@ -79,12 +85,68 @@ jobs:
           path: .open-next/
           retention-days: 7
 
-      - name: Deploy to Cloudflare Workers
+      - name: Determine deployment target
+        id: deploy-target
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "target=preview" >> "$GITHUB_OUTPUT"
+            echo "branch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+            SAFE_BRANCH=$(echo "${{ github.head_ref }}" | sed 's/[^a-zA-Z0-9-]/-/g' | tr '[:upper:]' '[:lower:]' | cut -c1-28)
+            echo "safe_branch=$SAFE_BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "target=production" >> "$GITHUB_OUTPUT"
+            echo "branch=main" >> "$GITHUB_OUTPUT"
+            echo "safe_branch=main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy to Cloudflare Workers (Production)
+        if: steps.deploy-target.outputs.target == 'production' && github.ref == 'refs/heads/main'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy
+
+      - name: Deploy to Cloudflare Workers (Preview)
+        if: steps.deploy-target.outputs.target == 'preview'
+        id: preview-deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --name portfolio-preview --var PREVIEW_BRANCH:${{ github.head_ref }}
+
+      - name: Create GitHub Deployment (Preview)
+        if: github.event_name == 'pull_request'
+        id: preview-gh-deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployUrl = '${{ steps.preview-deploy.outputs.deployment-url }}';
+            const safeBranch = '${{ steps.deploy-target.outputs.safe_branch }}';
+            const fallbackUrl = 'https://portfolio-preview.thenulldev.workers.dev';
+            const url = deployUrl || fallbackUrl;
+            
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+              environment: `preview-${safeBranch}`,
+              auto_merge: false,
+              required_contexts: [],
+              description: `Preview deployment for branch ${safeBranch}`,
+              transient_environment: true,
+              production_environment: false,
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'success',
+              environment: `preview-${safeBranch}`,
+              environment_url: url,
+              log_url: `https://dash.cloudflare.com/?to=/:account/workers-and-pages/overview`,
+            });
 
       - name: Create GitHub Deployment
         if: github.ref == 'refs/heads/main'
@@ -109,14 +171,76 @@ jobs:
               environment_url: 'https://portfolio.thenulldev.workers.dev',
               log_url: `https://dash.cloudflare.com/?to=/:account/workers-and-pages/overview`
             });
+
+      - name: Comment PR with Preview URL
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployUrl = '${{ steps.preview-deploy.outputs.deployment-url }}';
+            const branch = '${{ steps.deploy-target.outputs.branch }}';
+            const safeBranch = '${{ steps.deploy-target.outputs.safe_branch }}';
+            const fallbackUrl = 'https://portfolio-preview.thenulldev.workers.dev';
+            const url = deployUrl || fallbackUrl;
             
-            // Post deployment URL as PR/commit comment
-            const deployUrl = 'https://portfolio.thenulldev.workers.dev';
-            if (context.payload.pull_request) {
+            const body = `🚀 **Preview Deployment Ready**
+            
+            | Detail | Value |
+            |--------|-------|
+            | **Branch** | \`${branch}\` |
+            | **Preview URL** | [${url}](${url}) |
+            | **Status** | ✅ Live |
+            | **Type** | Shared preview worker (overwritten per-PR) |
+            
+            _Preview of branch \`${branch}\` is now live. The previous preview is overwritten._`;
+            
+            // Find existing comment to update
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            
+            const existing = comments.find(c => c.body.includes('🚀 **Preview Deployment Ready**'));
+            
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: `🚀 Deployed to ${deployUrl}`
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Comment PR on merge deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Find associated PR and post deploy notification
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+            });
+            
+            if (pulls.length > 0) {
+              const pr = pulls[0];
+              const body = `✅ **Merged to Production**
+            
+            Changes from this PR are now live at [https://portfolio.thenulldev.workers.dev](https://portfolio.thenulldev.workers.dev)`;
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
               });
             }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import Social from "@components/shared/Socials";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCode, faGraduationCap, faNewspaper } from "@fortawesome/free-solid-svg-icons";
+import PreviewBanner from "./PreviewBanner";
 
 type Tab = "skills" | "learning" | "blog";
 
@@ -98,6 +99,7 @@ export default function AppShell({ children, activeTab, onTabChange }: AppShellP
 
             {/* Main Content */}
             <main className="flex-1 h-full overflow-y-auto scroll-smooth bg-slate-50 dark:bg-slate-900 pb-20 lg:pb-0">
+                <PreviewBanner />
                 <div className="max-w-7xl mx-auto p-4 sm:p-6 lg:p-10 min-h-full">
                     
                     {/* Mobile Profile Header */}

--- a/src/components/layout/PreviewBanner.tsx
+++ b/src/components/layout/PreviewBanner.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCodeBranch } from "@fortawesome/free-solid-svg-icons";
+
+export default function PreviewBanner(): React.ReactElement | null {
+    const isPreview = process.env.NEXT_PUBLIC_PREVIEW === "true";
+    const branch = process.env.NEXT_PUBLIC_BRANCH_NAME;
+
+    if (!isPreview) return null;
+
+    return (
+        <div className="sticky top-0 z-[100] bg-amber-50 dark:bg-amber-900/30 border-b border-amber-200 dark:border-amber-800">
+            <div className="max-w-7xl mx-auto px-4 py-2 flex items-center justify-center gap-2 text-xs sm:text-sm text-amber-800 dark:text-amber-200">
+                <FontAwesomeIcon icon={faCodeBranch} className="w-3 h-3" />
+                <span className="font-medium">Preview Deployment</span>
+                <span className="text-amber-600/60 dark:text-amber-400/60">·</span>
+                <span className="font-mono text-xs bg-amber-100 dark:bg-amber-800/50 px-1.5 py-0.5 rounded">
+                    {branch || "unknown"}
+                </span>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## CI: Single shared preview worker + branch banner

Replaces branch-per-Worker previews with a single `portfolio-preview` Worker.

### Changes
- All PRs deploy to `--name portfolio-preview` (always overwritten)
- `NEXT_PUBLIC_PREVIEW=true` + `NEXT_PUBLIC_BRANCH_NAME` injected during PR builds
- `PreviewBanner` component: yellow sticky banner showing current branch name
- GitHub Deployments panel tracks both production and preview environments
- PR comments update in-place (no duplicate comments)
- Production deploy guarded to `refs/heads/main` only

### Preview URL
`https://portfolio-preview.thenulldev.workers.dev`

### Depends on
None — this is foundational CI infrastructure.
