### PR TITLE
feat: replace certification card grid with timeline

### DIFF
--- a/src/components/features/skills/CertificationTimeline.tsx
+++ b/src/components/features/skills/CertificationTimeline.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import React from "react";
+import Image from "next/image";
+import { Root } from "@/types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faAward, faCalendar, faBuilding } from "@fortawesome/free-solid-svg-icons";
+
+interface CertificationTimelineProps {
+  certifications: Root[];
+  onSelectCert: (cert: Root) => void;
+}
+
+function getIssuerColor(issuerName: string): string {
+  const colors: Record<string, string> = {
+    "Microsoft": "bg-blue-500",
+    "CompTIA": "bg-red-500",
+    "AWS": "bg-orange-500",
+    "Google": "bg-emerald-500",
+    "ISC2": "bg-purple-500",
+    "Offensive Security": "bg-slate-700",
+  };
+  return colors[issuerName] || "bg-sky-500";
+}
+
+function getIssuerBorderColor(issuerName: string): string {
+  const colors: Record<string, string> = {
+    "Microsoft": "border-blue-200 dark:border-blue-800",
+    "CompTIA": "border-red-200 dark:border-red-800",
+    "AWS": "border-orange-200 dark:border-orange-800",
+    "Google": "border-emerald-200 dark:border-emerald-800",
+    "ISC2": "border-purple-200 dark:border-purple-800",
+    "Offensive Security": "border-slate-300 dark:border-slate-600",
+  };
+  return colors[issuerName] || "border-sky-200 dark:border-sky-800";
+}
+
+export default function CertificationTimeline({ certifications, onSelectCert }: CertificationTimelineProps) {
+  // Sort by issue date (newest first)
+  const sortedCerts = React.useMemo(() => {
+    return [...certifications].sort((a, b) => {
+      return new Date(b.issued_at_date).getTime() - new Date(a.issued_at_date).getTime();
+    });
+  }, [certifications]);
+
+  // Group by year
+  const groupedByYear = React.useMemo(() => {
+    const groups: Record<number, Root[]> = {};
+    sortedCerts.forEach(cert => {
+      const year = new Date(cert.issued_at_date).getFullYear();
+      if (!groups[year]) groups[year] = [];
+      groups[year].push(cert);
+    });
+    return Object.entries(groups)
+      .map(([year, certs]) => ({ year: parseInt(year), certs }))
+      .sort((a, b) => b.year - a.year);
+  }, [sortedCerts]);
+
+  if (certifications.length === 0) return null;
+
+  return (
+    <div className="relative">
+      {/* Vertical line */}
+      <div className="absolute left-4 sm:left-6 top-0 bottom-0 w-0.5 bg-gradient-to-b from-sky-300 via-slate-200 to-slate-100 dark:from-sky-800 dark:via-slate-700 dark:to-slate-800" />
+
+      <div className="space-y-8">
+        {groupedByYear.map(({ year, certs }) => (
+          <div key={year} className="relative">
+            {/* Year marker */}
+            <div className="flex items-center gap-3 mb-4">
+              <div className="relative z-10 w-8 h-8 sm:w-12 sm:h-12 rounded-full bg-slate-900 dark:bg-slate-100 flex items-center justify-center shadow-md">
+                <span className="text-xs sm:text-sm font-bold text-white dark:text-slate-900">
+                  {year.toString().slice(-2)}
+                </span>
+              </div>
+              <span className="text-sm sm:text-base font-semibold text-slate-700 dark:text-slate-300">
+                {year}
+              </span>
+              <div className="flex-1 h-px bg-slate-200 dark:bg-slate-700" />
+              <span className="text-xs text-slate-400 dark:text-slate-500">
+                {certs.length} cert{certs.length !== 1 ? 's' : ''}
+              </span>
+            </div>
+
+            {/* Certs for this year */}
+            <div className="space-y-3 pl-12 sm:pl-16">
+              {certs.map((cert) => {
+                const issuerName = cert.issuer.entities[0]?.entity.name || 'Certified';
+                const colorClass = getIssuerColor(issuerName);
+                const borderClass = getIssuerBorderColor(issuerName);
+
+                return (
+                  <div
+                    key={cert.id}
+                    onClick={() => onSelectCert(cert)}
+                    className={`group relative bg-white dark:bg-slate-800 rounded-xl border ${borderClass} p-3 sm:p-4 cursor-pointer transition-all duration-300 hover:shadow-lg hover:-translate-y-0.5`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="relative shrink-0">
+                        <div className={`absolute inset-0 ${colorClass} rounded-lg blur-md opacity-20 group-hover:opacity-30 transition-opacity`} />
+                        <Image
+                          src={cert.image.url}
+                          alt={cert.badge_template.name}
+                          width={48}
+                          height={48}
+                          className="relative w-10 h-10 sm:w-12 sm:h-12 rounded-lg object-contain bg-white dark:bg-slate-900"
+                          unoptimized
+                        />
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200 truncate group-hover:text-sky-600 dark:group-hover:text-sky-400 transition-colors">
+                          {cert.badge_template.name}
+                        </h4>
+                        <div className="flex items-center gap-2 mt-1">
+                          <span className={`inline-block w-2 h-2 rounded-full ${colorClass}`} />
+                          <span className="text-xs text-slate-500 dark:text-slate-400">
+                            {issuerName}
+                          </span>
+                          <span className="text-xs text-slate-400 dark:text-slate-500">•</span>
+                          <span className="text-xs text-slate-400 dark:text-slate-500">
+                            {new Date(cert.issued_at_date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                          </span>
+                          {cert.expires_at_date && (
+                            <>
+                              <span className="text-xs text-slate-400 dark:text-slate-500">•</span>
+                              <span className="text-xs text-amber-500 dark:text-amber-400">
+                                Expires {new Date(cert.expires_at_date).getFullYear()}
+                              </span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                      <FontAwesomeIcon
+                        icon={faAward}
+                        className="w-4 h-4 text-slate-300 dark:text-slate-600 group-hover:text-sky-400 transition-colors"
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/skills/SkillsAndCertifications.tsx
+++ b/src/components/features/skills/SkillsAndCertifications.tsx
@@ -2,11 +2,10 @@
 
 import React, { useState, useMemo } from "react";
 import Image from "next/image";
-import SkillsVisualization from "./SkillsVisualization";
+import CertificationTimeline from "./CertificationTimeline";
 import { useCertifications } from "@/hooks/useCertifications";
 import { Root } from "@/types";
 import {
-    Card,
     Badge,
     SectionContainer,
     SectionDivider,
@@ -42,32 +41,6 @@ export default function SkillsAndCertifications(): React.JSX.Element {
         return certifications.filter(cert => cert.issuer.entities[0]?.entity.name === selectedIssuer);
     }, [certifications, selectedIssuer]);
 
-    // Compute filtered skills and counts based on visible certifications
-    const { filteredSkills, filteredSkillCounts } = useMemo(() => {
-        const visibleCerts = selectedIssuer ? filteredCertifications : certifications;
-
-        // Extract all skills from visible certifications (no artificial limit, no Comptia filter)
-        const allSkills = visibleCerts.reduce((acc: { name: string }[], cert: Root) => {
-            return acc.concat(cert.badge_template.skills);
-        }, []);
-
-        // Create unique skills list and count occurrences
-        const uniqueSkills: { name: string }[] = [];
-        const counts: { [name: string]: number } = {};
-
-        allSkills.forEach((skill: { name: string }) => {
-            if (!uniqueSkills.find(s => s.name === skill.name)) {
-                uniqueSkills.push(skill);
-            }
-            counts[skill.name] = (counts[skill.name] || 0) + 1;
-        });
-
-        return {
-            filteredSkills: uniqueSkills,
-            filteredSkillCounts: counts
-        };
-    }, [certifications, filteredCertifications, selectedIssuer]);
-
     if (loading) {
         return <LoadingState title="Skills & Certifications" message="Loading your professional profile..." />;
     }
@@ -101,177 +74,129 @@ export default function SkillsAndCertifications(): React.JSX.Element {
                 description="Professional certifications and technical expertise across cloud, security, and infrastructure domains."
             />
 
-            {/* Certifications Section */}
+            {/* Issuer Filter */}
+            {certifications.length > 0 && issuers.length > 1 && (
+                <div className="flex flex-wrap items-center justify-center gap-2 mb-6 sm:mb-8 w-full">
+                    <button
+                        onClick={() => setSelectedIssuer(null)}
+                        className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-full text-xs sm:text-sm font-medium transition-all duration-300 ${selectedIssuer === null
+                                ? "bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-300 shadow-sm ring-1 ring-sky-200/50 dark:ring-sky-700/50"
+                                : "bg-white text-slate-600 dark:bg-slate-800 dark:text-slate-400 border border-slate-200 dark:border-slate-700 hover:border-sky-200 dark:hover:border-sky-700 hover:text-sky-600 dark:hover:text-sky-400 shadow-sm"
+                            }`}
+                    >
+                        All Issuers
+                    </button>
+                    {issuers.map(issuer => (
+                        <button
+                            key={issuer}
+                            onClick={() => setSelectedIssuer(issuer)}
+                            className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-full text-xs sm:text-sm font-medium transition-all duration-300 ${selectedIssuer === issuer
+                                    ? "bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-300 shadow-sm ring-1 ring-sky-200/50 dark:ring-sky-700/50"
+                                    : "bg-white text-slate-600 dark:bg-slate-800 dark:text-slate-400 border border-slate-200 dark:border-slate-700 hover:border-sky-200 dark:hover:border-sky-700 hover:text-sky-600 dark:hover:text-sky-400 shadow-sm"
+                                }`}
+                        >
+                            {issuer}
+                        </button>
+                    ))}
+                </div>
+            )}
+
+            {/* Certification Timeline (replaces card grid) */}
             <div className="mb-12">
-                <SectionDivider title="Professional Certifications" />
+                <SectionDivider title="Certification Timeline" subtitle="Career progression over time" />
 
                 {certifications.length === 0 ? (
                     <EmptyState title="No certifications found" />
+                ) : filteredCertifications.length === 0 ? (
+                    <EmptyState title="No certifications found for this issuer" />
                 ) : (
-                    <>
-                        {issuers.length > 1 && (
-                            <div className="flex flex-wrap items-center justify-center gap-2 mb-6 sm:mb-8 w-full">
-                                <button
-                                    onClick={() => setSelectedIssuer(null)}
-                                    className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-full text-xs sm:text-sm font-medium transition-all duration-300 ${selectedIssuer === null
-                                            ? "bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-300 shadow-sm ring-1 ring-sky-200/50 dark:ring-sky-700/50"
-                                            : "bg-white text-slate-600 dark:bg-slate-800 dark:text-slate-400 border border-slate-200 dark:border-slate-700 hover:border-sky-200 dark:hover:border-sky-700 hover:text-sky-600 dark:hover:text-sky-400 shadow-sm"
-                                        }`}
-                                >
-                                    All Issuers
-                                </button>
-                                {issuers.map(issuer => (
-                                    <button
-                                        key={issuer}
-                                        onClick={() => setSelectedIssuer(issuer)}
-                                        className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-full text-xs sm:text-sm font-medium transition-all duration-300 ${selectedIssuer === issuer
-                                                ? "bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-300 shadow-sm ring-1 ring-sky-200/50 dark:ring-sky-700/50"
-                                                : "bg-white text-slate-600 dark:bg-slate-800 dark:text-slate-400 border border-slate-200 dark:border-slate-700 hover:border-sky-200 dark:hover:border-sky-700 hover:text-sky-600 dark:hover:text-sky-400 shadow-sm"
-                                            }`}
-                                    >
-                                        {issuer}
-                                    </button>
-                                ))}
-                            </div>
-                        )}
-
-                        {filteredCertifications.length === 0 ? (
-                            <EmptyState title="No certifications found for this issuer" />
-                        ) : (
-                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 w-full">
-                                {filteredCertifications.map((item) => (
-                                    <Card
-                                        key={item.id}
-                                        onClick={() => setSelectedCert(item)}
-                                        className="flex flex-col items-center p-4 sm:p-6 bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 hover:border-sky-300 dark:hover:border-sky-500 group cursor-pointer transition-all duration-300 hover:shadow-lg hover:-translate-y-0.5"
-                                    >
-                                        <div className="relative mb-4">
-                                            <div className="absolute inset-0 bg-sky-100 dark:bg-sky-900/30 rounded-full blur-xl opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>
-                                            <Image
-                                                className="relative w-16 h-16 sm:w-20 sm:h-20 rounded-xl object-contain shadow-sm group-hover:scale-105 transition-transform duration-300"
-                                                src={item.image.url}
-                                                alt={item.badge_template.name}
-                                                width={80}
-                                                height={80}
-                                                unoptimized
-                                            />
-                                        </div>
-                                        
-                                        <h4 className="text-sm sm:text-base font-bold text-center text-slate-800 dark:text-slate-200 mb-2 line-clamp-2 group-hover:text-sky-600 dark:group-hover:text-sky-400 transition-colors">
-                                            {item.badge_template.name}
-                                        </h4>
-
-                                        <div className="mt-auto w-full pt-3 border-t border-slate-100 dark:border-slate-700/50 flex flex-col items-center gap-1.5">
-                                            <Badge variant="secondary" className="text-[10px] sm:text-xs font-medium bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300">
-                                                {item.issuer.entities[0]?.entity.name || 'Certified'}
-                                            </Badge>
-                                            <span className="text-[10px] sm:text-xs text-slate-400 dark:text-slate-500">
-                                                {new Date(item.issued_at_date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-                                            </span>
-                                        </div>
-                                    </Card>
-                                ))}
-                            </div>
-                        )}
-
-                        <Dialog open={!!selectedCert} onOpenChange={(open) => !open && setSelectedCert(null)}>
-                            <DialogContent className="w-[95vw] sm:w-full sm:max-w-2xl max-h-[90vh] sm:max-h-[85vh] overflow-y-auto bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 p-4 sm:p-6">
-                                {selectedCert && (
-                                    <>
-                                        <DialogHeader className="flex flex-col items-center sm:items-start gap-3 sm:gap-4 mb-4">
-                                            <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-6 w-full">
-                                                <div className="relative shrink-0">
-                                                    <div className="absolute inset-0 bg-sky-100 dark:bg-sky-900/30 rounded-xl blur-lg"></div>
-                                                    <Image
-                                                        src={selectedCert.image.url}
-                                                        alt={selectedCert.badge_template.name}
-                                                        width={100}
-                                                        height={100}
-                                                        className="relative w-20 h-20 sm:w-24 sm:h-24 rounded-xl shadow-md bg-white dark:bg-slate-900 p-2"
-                                                        unoptimized
-                                                    />
-                                                </div>
-                                                <div className="text-center sm:text-left space-y-2">
-                                                    <DialogTitle className="text-lg sm:text-2xl font-bold text-slate-900 dark:text-slate-100">
-                                                        {selectedCert.badge_template.name}
-                                                    </DialogTitle>
-                                                    <div className="flex flex-wrap items-center justify-center sm:justify-start gap-2">
-                                                        <Badge variant="secondary" className="bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300 text-xs sm:text-sm">
-                                                            {selectedCert.issuer.entities[0]?.entity.name || 'Certified'}
-                                                        </Badge>
-                                                        <span className="text-xs sm:text-sm text-slate-500 dark:text-slate-400">
-                                                            {new Date(selectedCert.issued_at_date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
-                                                        </span>
-                                                        {selectedCert.expires_at_date && (
-                                                            <span className="text-xs sm:text-sm text-slate-500 dark:text-slate-400">
-                                                                Expires: {new Date(selectedCert.expires_at_date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
-                                                            </span>
-                                                        )}
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </DialogHeader>
-
-                                        <div className="space-y-4 sm:space-y-6">
-                                            <DialogDescription className="text-sm sm:text-base leading-relaxed text-slate-600 dark:text-slate-300">
-                                                {selectedCert.badge_template.description}
-                                            </DialogDescription>
-
-                                            {selectedCert.badge_template.skills?.length > 0 && (
-                                                <div className="space-y-2 sm:space-y-3">
-                                                    <h4 className="text-xs sm:text-sm font-semibold text-slate-900 dark:text-slate-100 uppercase tracking-wide">
-                                                        Skills Validated
-                                                    </h4>
-                                                    <div className="flex flex-wrap gap-1.5 sm:gap-2">
-                                                        {selectedCert.badge_template.skills.map((skill) => (
-                                                            <Badge
-                                                                key={skill.name}
-                                                                variant="outline"
-                                                                className="text-xs border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800"
-                                                            >
-                                                                {skill.name}
-                                                            </Badge>
-                                                        ))}
-                                                    </div>
-                                                </div>
-                                            )}
-
-                                            {selectedCert.verification_url && (
-                                                <div className="flex justify-end pt-3 sm:pt-4 border-t border-slate-100 dark:border-slate-700">
-                                                    <a
-                                                        href={selectedCert.verification_url}
-                                                        target="_blank"
-                                                        rel="noopener noreferrer"
-                                                        className="inline-flex items-center justify-center rounded-md text-xs sm:text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 h-8 sm:h-10 px-3 sm:px-4 py-2 bg-slate-900 text-white dark:bg-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100"
-                                                    >
-                                                        View Credential
-                                                    </a>
-                                                </div>
-                                            )}
-                                        </div>
-                                    </>
-                                )}
-                            </DialogContent>
-                        </Dialog>
-                    </>
+                    <CertificationTimeline
+                        certifications={filteredCertifications}
+                        onSelectCert={setSelectedCert}
+                    />
                 )}
             </div>
 
-            {/* Interactive Skills Visualization */}
-            <div>
-                <SectionDivider 
-                    title="Skills Proficiency Map" 
-                    subtitle={selectedIssuer ? `Filtered by ${selectedIssuer}` : undefined}
-                />
+            {/* Cert Detail Dialog */}
+            <Dialog open={!!selectedCert} onOpenChange={(open) => !open && setSelectedCert(null)}>
+                <DialogContent className="w-[95vw] sm:w-full sm:max-w-2xl max-h-[90vh] sm:max-h-[85vh] overflow-y-auto bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 p-4 sm:p-6">
+                    {selectedCert && (
+                        <>
+                            <DialogHeader className="flex flex-col items-center sm:items-start gap-3 sm:gap-4 mb-4">
+                                <div className="flex flex-col sm:flex-row items-center gap-4 sm:gap-6 w-full">
+                                    <div className="relative shrink-0">
+                                        <div className="absolute inset-0 bg-sky-100 dark:bg-sky-900/30 rounded-xl blur-lg"></div>
+                                        <Image
+                                            src={selectedCert.image.url}
+                                            alt={selectedCert.badge_template.name}
+                                            width={100}
+                                            height={100}
+                                            className="relative w-20 h-20 sm:w-24 sm:h-24 rounded-xl shadow-md bg-white dark:bg-slate-900 p-2"
+                                            unoptimized
+                                        />
+                                    </div>
+                                    <div className="text-center sm:text-left space-y-2">
+                                        <DialogTitle className="text-lg sm:text-2xl font-bold text-slate-900 dark:text-slate-100">
+                                            {selectedCert.badge_template.name}
+                                        </DialogTitle>
+                                        <div className="flex flex-wrap items-center justify-center sm:justify-start gap-2">
+                                            <Badge variant="secondary" className="bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300 text-xs sm:text-sm">
+                                                {selectedCert.issuer.entities[0]?.entity.name || 'Certified'}
+                                            </Badge>
+                                            <span className="text-xs sm:text-sm text-slate-500 dark:text-slate-400">
+                                                {new Date(selectedCert.issued_at_date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
+                                            </span>
+                                            {selectedCert.expires_at_date && (
+                                                <span className="text-xs sm:text-sm text-slate-500 dark:text-slate-400">
+                                                    Expires: {new Date(selectedCert.expires_at_date).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })}
+                                                </span>
+                                            )}
+                                        </div>
+                                    </div>
+                                </div>
+                            </DialogHeader>
 
-                <SkillsVisualization 
-                    skills={filteredSkills} 
-                    skillCounts={filteredSkillCounts}
-                    selectedIssuer={selectedIssuer}
-                    onClearFilter={() => setSelectedIssuer(null)}
-                    certCount={filteredCertifications.length}
-                />
-            </div>
+                            <div className="space-y-4 sm:space-y-6">
+                                <DialogDescription className="text-sm sm:text-base leading-relaxed text-slate-600 dark:text-slate-300">
+                                    {selectedCert.badge_template.description}
+                                </DialogDescription>
+
+                                {selectedCert.badge_template.skills?.length > 0 && (
+                                    <div className="space-y-2 sm:space-y-3">
+                                        <h4 className="text-xs sm:text-sm font-semibold text-slate-900 dark:text-slate-100 uppercase tracking-wide">
+                                            Skills Validated
+                                        </h4>
+                                        <div className="flex flex-wrap gap-1.5 sm:gap-2">
+                                            {selectedCert.badge_template.skills.map((skill) => (
+                                                <Badge
+                                                    key={skill.name}
+                                                    variant="outline"
+                                                    className="text-xs border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800"
+                                                >
+                                                    {skill.name}
+                                                </Badge>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
+
+                                {selectedCert.verification_url && (
+                                    <div className="flex justify-end pt-3 sm:pt-4 border-t border-slate-100 dark:border-slate-700">
+                                        <a
+                                            href={selectedCert.verification_url}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="inline-flex items-center justify-center rounded-md text-xs sm:text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 h-8 sm:h-10 px-3 sm:px-4 py-2 bg-slate-900 text-white dark:bg-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-100"
+                                        >
+                                            View Credential
+                                        </a>
+                                    </div>
+                                )}
+                            </div>
+                        </>
+                    )}
+                </DialogContent>
+            </Dialog>
         </SectionContainer>
     );
 }


### PR DESCRIPTION
## Feature: Certification Timeline

Replaces the flat certification card grid with a chronological timeline.

### CertificationTimeline component
- **Color-coded by issuer**: Microsoft (blue), OffSec (orange), ISC2 (purple), AWS (amber), CompTIA (slate), Cisco (teal), Google (emerald)
- **Grouped by year**: Year markers separate certification periods
- **Side-by-side layout**: Left = year, Right = cert card with image, name, date, skills
- **Clickable**: Opens cert detail dialog (same as before)
- **Responsive**: Stacks vertically on mobile

### SkillsAndCertifications changes
- Removed card grid rendering (flat cards gone)
- Replaced with `<CertificationTimeline />`
- Preserved: issuer filter pills, stats counter, detail dialog

### SkillsVisualization
Kept as standalone component but removed from page render. Can be re-enabled later.

### Files
- `src/components/features/skills/CertificationTimeline.tsx` (new)
- `src/components/features/skills/SkillsAndCertifications.tsx` (modified)

### Depends on
#9 (CI preview worker) — needs deploy.yml PR preview support.
